### PR TITLE
Add export options in react/DashboardHeader

### DIFF
--- a/react/src/components/DashboardHeader/DashboardHeader.tsx
+++ b/react/src/components/DashboardHeader/DashboardHeader.tsx
@@ -1,10 +1,21 @@
-import { Badge, Icon, Metric, Text } from "@tremor/react";
+import { Badge, Button, Icon, Metric, Text } from "@tremor/react";
 
-import React, { useEffect, useState } from "react";
+import React, { Fragment, useCallback, useEffect, useState } from "react";
 import { useDashboard } from "../Dashboard/Dashboard";
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
-import { PresentationChartBarIcon } from "@heroicons/react/24/outline";
+import {
+  ChevronDownIcon,
+  DocumentIcon,
+  DocumentChartBarIcon,
+  PhotoIcon,
+  PresentationChartBarIcon,
+  TableCellsIcon,
+} from "@heroicons/react/24/outline";
+import { Menu, Transition } from "@headlessui/react";
+import { toast } from "sonner";
+import { useBackend } from "../Wrapper";
+
 dayjs.extend(relativeTime);
 
 export const LastUpdatedBadge: React.FC<{ date: string }> = ({ date }) => {
@@ -29,6 +40,37 @@ export const LastUpdatedBadge: React.FC<{ date: string }> = ({ date }) => {
 
 export const DashboardHeader: React.FC = ({}) => {
   const { dashboard } = useDashboard();
+  const backend = useBackend();
+
+  const exportDashboard = useCallback(
+    (format: "csv" | "xlsx" | "pdf" | "png") => {
+      if (!backend || !dashboard) {
+        return;
+      }
+      toast.promise(
+        async () => {
+          const blob = await backend.dashboard(dashboard.id).export(format);
+          return window.URL.createObjectURL(blob);
+        },
+        {
+          loading: `Exporting dashboard as ${format}...`,
+          success: (url: string) => {
+            let a = document.createElement("a");
+            a.download = dashboard.title + "." + format;
+            a.href = url;
+            document.body.appendChild(a);
+            a.click();
+            a.remove();
+            return "Dashboard exported successfully";
+          },
+          error: (e: any) => {
+            return "Failed to export dashboard: " + e.message;
+          },
+        }
+      );
+    },
+    [dashboard, backend]
+  );
 
   return (
     <section className="onv-dashboard-header foreground-color sticky z-10 border-b border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-900 top-0">
@@ -58,6 +100,99 @@ export const DashboardHeader: React.FC = ({}) => {
                 <div className="h-4 w-2/5 rounded-md bg-gray-100 dark:bg-gray-700" />
               </div>
             )}
+          </div>
+          <div className="flex flex-row gap-2">
+            <Menu as="div" className="relative inline-block text-left">
+              <Menu.Button as="div">
+                <Button
+                  icon={ChevronDownIcon}
+                  iconPosition="right"
+                  size="xs"
+                  variant="secondary"
+                  disabled={!dashboard}
+                >
+                  Download
+                </Button>
+              </Menu.Button>
+              <Transition
+                as={Fragment}
+                enter="transition ease-out duration-100"
+                enterFrom="transform opacity-0 scale-95"
+                enterTo="transform opacity-100 scale-100"
+                leave="transition ease-in duration-75"
+                leaveFrom="transform opacity-100 scale-100"
+                leaveTo="transform opacity-0 scale-95"
+              >
+                <Menu.Items className="absolute right-0 mt-2 w-56 origin-top-right divide-y divide-gray-100 rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none">
+                  <div className="px-1 py-1 ">
+                    <Menu.Item>
+                      {({ active }) => (
+                        <button
+                          onClick={() => exportDashboard("xlsx")}
+                          className={`${
+                            active ? "bg-blue-500 text-white" : "text-gray-900"
+                          } group flex w-full items-center rounded-md px-2 py-2 text-sm`}
+                        >
+                          <DocumentChartBarIcon
+                            className="mr-2 h-5 w-5"
+                            aria-hidden="true"
+                          />
+                          Download excel
+                        </button>
+                      )}
+                    </Menu.Item>
+                    <Menu.Item>
+                      {({ active }) => (
+                        <button
+                          onClick={() => exportDashboard("csv")}
+                          className={`${
+                            active ? "bg-blue-500 text-white" : "text-gray-900"
+                          } group flex w-full items-center rounded-md px-2 py-2 text-sm`}
+                        >
+                          <TableCellsIcon
+                            className="mr-2 h-5 w-5"
+                            aria-hidden="true"
+                          />
+                          Download csv
+                        </button>
+                      )}
+                    </Menu.Item>
+                    <Menu.Item>
+                      {({ active }) => (
+                        <button
+                          onClick={() => exportDashboard("png")}
+                          className={`${
+                            active ? "bg-blue-500 text-white" : "text-gray-900"
+                          } group flex w-full items-center rounded-md px-2 py-2 text-sm`}
+                        >
+                          <PhotoIcon
+                            className="mr-2 h-5 w-5"
+                            aria-hidden="true"
+                          />
+                          Download png
+                        </button>
+                      )}
+                    </Menu.Item>
+                    <Menu.Item>
+                      {({ active }) => (
+                        <button
+                          onClick={() => exportDashboard("pdf")}
+                          className={`${
+                            active ? "bg-blue-500 text-white" : "text-gray-900"
+                          } group flex w-full items-center rounded-md px-2 py-2 text-sm`}
+                        >
+                          <DocumentIcon
+                            className="mr-2 h-5 w-5"
+                            aria-hidden="true"
+                          />
+                          Download pdf
+                        </button>
+                      )}
+                    </Menu.Item>
+                  </div>
+                </Menu.Items>
+              </Transition>
+            </Menu>
           </div>
         </div>
       </main>


### PR DESCRIPTION
### UI Changes
| old | new |
| ------------- | ------------- |
|<img width="1066" alt="image" src="https://github.com/onvo-ai/sdks/assets/10618953/cc1b2da5-65e7-4bd4-a46c-5d1b9c42c9fe">|<img width="1066" alt="image" src="https://github.com/onvo-ai/sdks/assets/10618953/3113669f-0b1b-4bfc-9bc4-81882376e7c1">|
### What changed?
Added export options to DashboardHeader in React embed library similar to our platform utility. 

